### PR TITLE
[all] Release v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Next
+# 0.10.0 (2019-11-21)
 
 - **[Breaking change]** Rename from `swf-tree`  to `swf-types`.
 - **[Breaking change]** Replace `Unknown` tag with `RawBody`.

--- a/rs/Cargo.lock
+++ b/rs/Cargo.lock
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "swf-types"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -96,10 +96,10 @@ dependencies = [
 
 [[package]]
 name = "swf-types-bin"
-version = "0.5.0"
+version = "0.1.0"
 dependencies = [
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "swf-types 0.9.0",
+ "swf-types 0.10.0",
 ]
 
 [[package]]

--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swf-types"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Charles Samborski <demurgos@demurgos.net>"]
 description = "Type definitions for the SWF file format"
 documentation = "https://github.com/open-flash/swf-types"

--- a/rs/bin/Cargo.toml
+++ b/rs/bin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swf-types-bin"
-version = "0.5.0"
+version = "0.1.0"
 authors = ["Charles Samborski <demurgos@demurgos.net>"]
 description = "Type definitions for the SWF file format"
 documentation = "https://github.com/open-flash/swf-types"

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swf-types",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "homepage": "https://github.com/open-flash/swf-types",
   "description": "Type definitions for the SWF file format",
   "main": "dist/lib/index.js",


### PR DESCRIPTION
- **[Breaking change]** Rename from `swf-tree`  to `swf-types`.
- **[Breaking change]** Replace `Unknown` tag with `RawBody`.
- **[Feature]** Add `Raw` tag.

## Rust

- **[Feature]** Make `serde` optional (enabled by default) ([#73](https://github.com/open-flash/swf-types/issues/73)).
- **[Fix]** Expose `float_is` module, to allow bit-pattern float equality.
- **[Fix]** Update dependencies.

## Typescript

- **[Fix]** Fix pre-release npm tag.