### PR TITLE
[all] Rename custom image media type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Next
 
 - **[Breaking change]** Update `DoAbc` to allow optional flags and name.
+- **[Breaking change]** Rename custom image media type to be closer to the corresponding tag names.
 
 # 0.10.0 (2019-11-21)
 

--- a/rs/src/image.rs
+++ b/rs/src/image.rs
@@ -3,12 +3,10 @@ use ::serde::{Deserialize, Serialize};
 
 /// Supported image types
 ///
-/// - `x-partial-jpeg`: JPEG file without  Tables/Misc chunk. It has to be defined in a
+/// - `x-swf-partial-jpeg`: JPEG file without  Tables/Misc chunk. It has to be defined in a
 ///   `DefineJpegTables` tag and injected in the first Start Of Frame (SOF) JPEG chunk.
-/// - `x-ajpeg`: JPEG with alpha mask (see DefineBitsJPEG3):
-///   `x-ajpeg` :: `jpeg_size` `jpeg` `alpha`
-/// - `x-ajpegd`: JPEG with alpha mask and deblocking (see DefineBitsJPEG4):
-///   `x-ajpegd` :: `jpeg_size` `deblock` `jpeg` `alpha`
+/// - `x-swf-jpeg3`: JPEG with alpha mask (see DefineBitsJPEG3)
+/// - `x-swf-jpeg4`: JPEG with alpha mask and deblocking (see DefineBitsJPEG4)
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum ImageType {
@@ -18,14 +16,14 @@ pub enum ImageType {
   Gif,
   #[cfg_attr(feature = "serde", serde(rename = "image/png"))]
   Png,
-  #[cfg_attr(feature = "serde", serde(rename = "image/x-partial-jpeg"))]
-  PartialJpeg,
-  #[cfg_attr(feature = "serde", serde(rename = "image/x-ajpeg"))]
-  Ajpeg,
-  #[cfg_attr(feature = "serde", serde(rename = "image/x-ajpegd"))]
-  Ajpegd,
-  #[cfg_attr(feature = "serde", serde(rename = "image/x-swf-bmp"))]
-  SwfBmp,
-  #[cfg_attr(feature = "serde", serde(rename = "image/x-swf-abmp"))]
-  SwfAbmp,
+  #[cfg_attr(feature = "serde", serde(rename = "image/x-swf-partial-jpeg"))]
+  SwfPartialJpeg,
+  #[cfg_attr(feature = "serde", serde(rename = "image/x-swf-jpeg3"))]
+  SwfJpeg3,
+  #[cfg_attr(feature = "serde", serde(rename = "image/x-swf-jpeg4"))]
+  SwfJpeg4,
+  #[cfg_attr(feature = "serde", serde(rename = "image/x-swf-lossless1"))]
+  SwfLossless1,
+  #[cfg_attr(feature = "serde", serde(rename = "image/x-swf-lossless2"))]
+  SwfLossless2,
 }

--- a/ts/src/lib/image-type.ts
+++ b/ts/src/lib/image-type.ts
@@ -2,22 +2,20 @@ import { Ucs2StringType } from "kryo/types/ucs2-string";
 import { WhiteListType } from "kryo/types/white-list";
 
 /**
- * - `x-partial-jpeg`: JPEG file without  Tables/Misc chunk. It has to be defined in a
+ * - `x-swf-partial-jpeg`: JPEG file without  Tables/Misc chunk. It has to be defined in a
  *   `DefineJpegTables` tag and injected in the first Start Of Frame (SOF) JPEG chunk.
- * - `x-ajpeg`: JPEG with alpha mask (see DefineBitsJPEG3):
- *   `x-ajpeg` :: `jpeg_size` `jpeg` `alpha`
- * - `x-ajpegd`: JPEG with alpha mask and deblocking (see DefineBitsJPEG4):
- *   `x-ajpegd` :: `jpeg_size` `deblock` `jpeg` `alpha`
+ * - `x-swf-jpeg3`: JPEG with alpha mask (see DefineBitsJPEG3)
+ * - `x-swf-jpeg4`: JPEG with alpha mask and deblocking (see DefineBitsJPEG4)
  */
 export type ImageType =
   "image/jpeg"
   | "image/gif"
   | "image/png"
-  | "image/x-partial-jpeg"
-  | "image/x-ajpeg"
-  | "image/x-ajpegd"
-  | "image/x-swf-bmp"
-  | "image/x-swf-abmp";
+  | "image/x-swf-partial-jpeg"
+  | "image/x-swf-jpeg3"
+  | "image/x-swf-jpeg4"
+  | "image/x-swf-lossless1"
+  | "image/x-swf-lossless2";
 
 export const $ImageType: WhiteListType<ImageType> = new WhiteListType({
   itemType: new Ucs2StringType({maxLength: Infinity}),
@@ -25,10 +23,10 @@ export const $ImageType: WhiteListType<ImageType> = new WhiteListType({
     "image/jpeg" as const,
     "image/gif" as const,
     "image/png" as const,
-    "image/x-partial-jpeg" as const,
-    "image/x-ajpeg" as const,
-    "image/x-ajpegd" as const,
-    "image/x-swf-bmp" as const,
-    "image/x-swf-abmp" as const,
+    "image/x-swf-partial-jpeg" as const,
+    "image/x-swf-jpeg3" as const,
+    "image/x-swf-jpeg4" as const,
+    "image/x-swf-lossless1" as const,
+    "image/x-swf-lossless2" as const,
   ],
 });


### PR DESCRIPTION
The new names are closer to the corresponding tag names, so they should be more obvious. They also all have the explicit `x-swf` prefix signalling they are custom image types.