### PR TITLE
[all] Release v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Next
+# 0.11.0 (2020-02-05)
 
 - **[Breaking change]** Update `DoAbc` to allow optional flags and name.
 - **[Breaking change]** Rename custom image media type to be closer to the corresponding tag names.

--- a/rs/Cargo.lock
+++ b/rs/Cargo.lock
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "swf-types"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -99,7 +99,7 @@ name = "swf-types-bin"
 version = "0.1.0"
 dependencies = [
  "serde_json_v8 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "swf-types 0.10.0",
+ "swf-types 0.11.0",
 ]
 
 [[package]]

--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swf-types"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Charles Samborski <demurgos@demurgos.net>"]
 description = "Type definitions for the SWF file format"
 documentation = "https://github.com/open-flash/swf-types"

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swf-types",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "homepage": "https://github.com/open-flash/swf-types",
   "description": "Type definitions for the SWF file format",
   "main": "dist/lib/index.js",


### PR DESCRIPTION
- **[Breaking change]** Update `DoAbc` to allow optional flags and name.
- **[Breaking change]** Rename custom image media type to be closer to the corresponding tag names.

## Rust

- **[Internal]** Add clippy support ([#83](https://github.com/open-flash/swf-types/issues/83)).