### PR TITLE
[all] Release v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Next
+# 0.12.0 (2020-09-05)
 
 - **[Breaking change]** Use `PascalCase` for enums and types.
 - **[Breaking change]** Require `colorTransform` in `ButtonRecord` ([#85](https://github.com/open-flash/swf-types/issues/85)).

--- a/rs/Cargo.lock
+++ b/rs/Cargo.lock
@@ -101,7 +101,7 @@ dependencies = [
 
 [[package]]
 name = "swf-types"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.115 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -115,7 +115,7 @@ name = "swf-types-bin"
 version = "0.1.0"
 dependencies = [
  "serde_json_v8 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "swf-types 0.11.0",
+ "swf-types 0.12.0",
 ]
 
 [[package]]

--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swf-types"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Charles Samborski <demurgos@demurgos.net>"]
 description = "Type definitions for the SWF file format"
 documentation = "https://github.com/open-flash/swf-types"

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swf-types",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Type definitions for the SWF file format",
   "licenses": [
     {


### PR DESCRIPTION
- **[Breaking change]** Use `PascalCase` for enums and types.
- **[Breaking change]** Require `colorTransform` in `ButtonRecord` ([#85](https://github.com/open-flash/swf-types/issues/85)).
- **[Breaking change]** Rename `DefineButton.characters` to `records` ([#86](https://github.com/open-flash/swf-types/issues/86)).

## Rust

- **[Fix]** Update dependencies.

## Typescript

- **[Breaking change]** Update to native ESM.
- **[Internal]** Switch from `tslint` to `eslint`.